### PR TITLE
feat: add workflow dispatch event to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,14 +1,8 @@
 name: Codemod publish
 
 on:
+  workflow_dispatch:
   push:
-    paths:
-      - "codemods/**"
-    branches:
-      - main
-  pull_request:
-    types:
-      - closed
     paths:
       - "codemods/**"
     branches:
@@ -16,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -39,8 +33,27 @@ jobs:
         run: pnpm install
       - name: Run test
         run: pnpm recursive run test
+  paths-filter:
+    name: Check for .codemodrc.json files changes
+    runs-on: ubuntu-latest
+    outputs:
+      codemods: ${{ steps.filter.outputs.codemods }}
+      codemods_files: ${{ steps.filter.outputs.codemods_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        name: Filter codemods
+        with:
+          list-files: json
+          filters: |
+            codemods:
+              - '**/.codemodrc.json'
+
   publish:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    needs: paths-filter
+    if: always() && needs.paths-filter.outputs.codemods == 'true'
     env:
       CODEMOD_API_KEY: ${{ secrets.CODEMOD_API_KEY }}
     steps:
@@ -49,21 +62,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: filter
-        name: Filter codemods
-        with:
-          list-files: shell
-          filters: |
-            codemods:
-              - '**/.codemodrc.json'
-
       - name: export files
         run: |
-          echo "Modified files: ${{steps.filter.outputs.codemods_files}}"
-          echo "CODEMOD_FILES=${{steps.filter.outputs.codemods_files}}" >> $GITHUB_ENV
-          echo "Modified status: ${{steps.filter.outputs.codemods}}"
-          echo "CODEMOD_STATUS=${{steps.filter.outputs.codemods}}" >> $GITHUB_ENV
+          echo "Modified files: ${{needs.paths-filter.outputs.codemods_files}}"
+          echo "Modified status: ${{needs.paths-filter.outputs.codemods}}"
+          echo "CODEMOD_STATUS=${{needs.paths-filter.outputs.codemods}}" >> $GITHUB_ENV
+          echo "${{needs.paths-filter.outputs.codemods}}"
+          if [ "${{needs.paths-filter.outputs.codemods}}" == 'true' ]; then
+            echo "CODEMOD_FILES=${{needs.paths-filter.outputs.codemods_files}}" >> $GITHUB_ENV
+          else
+            echo "CODEMOD_FILES=$(find codemods -name '.codemodrc.json' -type f -exec echo -n '\"{}\" ' \;)" >> $GITHUB_ENV
+          fi
 
       - uses: pnpm/action-setup@v4
         with:
@@ -77,16 +86,26 @@ jobs:
 
       - name: Run publish codemod
         run: |
-          if [ -n "$CODEMOD_STATUS" ]; then
-            echo "Modified files: $CODEMOD_FILES"
-            ROOT_DIR=$(pwd)
-            for FILE in $CODEMOD_FILES; do
-              DIR=$(dirname "$FILE")
+          echo "Modified files: $CODEMOD_FILES"
+          ROOT_DIR=$(pwd)
+          if [[ "$CODEMOD_FILES" == *"["* ]]; then
+            # Handle array format
+            # Use IFS to handle spaces in filenames
+            IFS=',' read -ra FILES <<< "$(echo "$CODEMOD_FILES" | tr -d '[]')"
+            for FILE in "${FILES[@]}"; do
+              CLEANED_PATH="${FILE//[\'\"]}"
+              DIR=$(dirname "$CLEANED_PATH")
               echo "Checking codemod: $DIR"
               cd "$ROOT_DIR/$DIR"
               pnpm install
-              npx codemod publish
+              npx codemod publish || true
             done
           else
-            echo "No codemods found"
+            # Handle single file format
+            CLEANED_PATH="${CODEMOD_FILES//[\'\"]}"
+            DIR=$(dirname "$CLEANED_PATH")
+            echo "Checking codemod: $DIR"
+            cd "$ROOT_DIR/$DIR"
+            pnpm install
+            npx codemod publish || true
           fi


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod Commons! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine  
feat(cli)!: revamp the design (BREAKING CHANGE)  
fix(cli): fix a bug for the formatter  
chore(backend): upgrade node  
docs: improve codemod publish docs  
refactor(registry www): modularize filters  
test(vsce): add tests for VS Code extension  
-->

#### 📚 Description

Added `workflow_dispatch` event to the publishing workflow, enabling manual triggering of the workflow when needed.  
This enhances flexibility by allowing users to publish changes outside of the predefined triggers.

#### 🧪 Test Plan

- Verified the workflow dispatch functionality by triggering the workflow manually in a forked repository.  
- Confirmed that the workflow runs successfully and is complete as expected.