### PR TITLE
refactor(.github/workflows/publish.yaml): use matrix strategy for publishing codemods

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,30 +9,6 @@ on:
       - main
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Check prettier
-        uses: creyD/prettier_action@v4.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prettier_options: --check
-
-      - name: Install dependencies
-        run: pnpm install
-      - name: Run test
-        run: pnpm recursive run test
   paths-filter:
     name: Check for .codemodrc.json files changes
     runs-on: ubuntu-latest
@@ -50,10 +26,32 @@ jobs:
             codemods:
               - '**/.codemodrc.json'
 
-  publish:
+  prepare-matrix:
+    name: Prepare matrix
     runs-on: ubuntu-latest
     needs: paths-filter
     if: always() && needs.paths-filter.outputs.codemods == 'true'
+    outputs:
+      codemod_files: ${{ steps.set-matrix.outputs.codemod_files }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set matrix for codemods
+        id: set-matrix
+        run: |
+          FILES_JSON=$(echo '${{ needs.paths-filter.outputs.codemods_files }}' | jq -c '{include: map({file: .})}')
+          echo "codemod_files=$FILES_JSON" >> "$GITHUB_OUTPUT"
+          echo "Matrix JSON: $FILES_JSON"
+
+  publish:
+    name: Publish ${{ matrix.file }}
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    strategy:
+      matrix: ${{fromJson(needs.prepare-matrix.outputs.codemod_files)}}
     env:
       CODEMOD_API_KEY: ${{ secrets.CODEMOD_API_KEY }}
     steps:
@@ -61,18 +59,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: export files
-        run: |
-          echo "Modified files: ${{needs.paths-filter.outputs.codemods_files}}"
-          echo "Modified status: ${{needs.paths-filter.outputs.codemods}}"
-          echo "CODEMOD_STATUS=${{needs.paths-filter.outputs.codemods}}" >> $GITHUB_ENV
-          echo "${{needs.paths-filter.outputs.codemods}}"
-          if [ "${{needs.paths-filter.outputs.codemods}}" == 'true' ]; then
-            echo "CODEMOD_FILES=${{needs.paths-filter.outputs.codemods_files}}" >> $GITHUB_ENV
-          else
-            echo "CODEMOD_FILES=$(find codemods -name '.codemodrc.json' -type f -exec echo -n '\"{}\" ' \;)" >> $GITHUB_ENV
-          fi
 
       - uses: pnpm/action-setup@v4
         with:
@@ -82,30 +68,22 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: pnpm install -g codemod
-
-      - name: Run publish codemod
         run: |
-          echo "Modified files: $CODEMOD_FILES"
-          ROOT_DIR=$(pwd)
-          if [[ "$CODEMOD_FILES" == *"["* ]]; then
-            # Handle array format
-            # Use IFS to handle spaces in filenames
-            IFS=',' read -ra FILES <<< "$(echo "$CODEMOD_FILES" | tr -d '[]')"
-            for FILE in "${FILES[@]}"; do
-              CLEANED_PATH="${FILE//[\'\"]}"
-              DIR=$(dirname "$CLEANED_PATH")
-              echo "Checking codemod: $DIR"
-              cd "$ROOT_DIR/$DIR"
-              pnpm install
-              npx codemod publish || true
-            done
-          else
-            # Handle single file format
-            CLEANED_PATH="${CODEMOD_FILES//[\'\"]}"
-            DIR=$(dirname "$CLEANED_PATH")
-            echo "Checking codemod: $DIR"
-            cd "$ROOT_DIR/$DIR"
-            pnpm install
-            npx codemod publish || true
-          fi
+          sudo apt-get install libsecret-1-dev
+          pnpm install -g codemod
+
+      - name: Test codemod
+        run: |
+          DIR=$(dirname "${{ matrix.file }}")
+          echo "Testing codemod in: $DIR"
+          cd "$DIR"
+          pnpm install
+          pnpm run test
+
+      - name: Publish codemod
+        run: |
+          DIR=$(dirname "${{ matrix.file }}")
+          echo "Publishing codemod in: $DIR"
+          cd "$DIR"
+          pnpm install
+          npx codemod publish


### PR DESCRIPTION
#### 📚 Description

This PR refactors the GitHub Actions workflow for publishing codemods by introducing a matrix strategy. The key changes include:

- Removing the redundant test step from the workflow.
- Adding a `prepare-matrix` job to dynamically generate a matrix of new `.codemodrc.json` files or modified `.codemodrc.json` files.
- Updating the `publish` job to run in parallel for each modified codemod, improving efficiency.
- Add a test step for each codemod before publishing

#### 🧪 Test Plan

- Triggered the workflow manually using `workflow_dispatch`.
- Pushed changes to `codemods/**` on the `main` branch to validate automatic execution.
- Verified that the matrix strategy correctly processes individual codemods in parallel