### PR TITLE
fix(workflow/publish): improve publish process with pnpx for run codemod CLI, fail-fast fix, and test step update

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,6 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-matrix
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.prepare-matrix.outputs.codemod_files)}}
     env:
       CODEMOD_API_KEY: ${{ secrets.CODEMOD_API_KEY }}
@@ -78,12 +79,11 @@ jobs:
           echo "Testing codemod in: $DIR"
           cd "$DIR"
           pnpm install
-          pnpm run test
+          pnpm run --if-present test
 
       - name: Publish codemod
         run: |
           DIR=$(dirname "${{ matrix.file }}")
           echo "Publishing codemod in: $DIR"
           cd "$DIR"
-          pnpm install
-          npx codemod publish
+          pnpx codemod publish


### PR DESCRIPTION
#### 📚 Description
This PR improves the `codemod publish` GitHub Action workflow by:
- Using `pnpx` instead of `npx` for `codemod publish`, ensuring a more consistent execution.
- Removing unnecessary dependency installations to optimize performance.
- Adding `--if-present` to the test step prevents failures when the test script is absent.
- Setting `fail-fast: false` ensures all matrix jobs run even if one fails.

#### 🧪 Test Plan
- Verified workflow execution on a feature branch.
- Ensured `codemod publish` runs successfully without redundant installations.
- Confirmed that failing tests do not stop the entire workflow.