### PR TITLE
fix(.github/workflows/publish): fix repo build in test step

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,8 +77,9 @@ jobs:
         run: |
           DIR=$(dirname "${{ matrix.file }}")
           echo "Testing codemod in: $DIR"
-          cd "$DIR"
           pnpm install
+          pnpm run build
+          cd "$DIR"
           pnpm run --if-present test
 
       - name: Publish codemod


### PR DESCRIPTION
#### 📚 Description

This PR fixes the build process in the publishing workflow's test step. Previously, the step failed due to missing build artifacts. This change ensures that the tooling is built before running the tests, preventing issues caused by missing compiled files.

#### 🧪 Test Plan
1. Ensure that the workflow correctly builds the toolings before running tests.
2. Verify that the publish step is completed successfully without errors.